### PR TITLE
Update README

### DIFF
--- a/.github/workflows/first-time-setup.yml
+++ b/.github/workflows/first-time-setup.yml
@@ -42,8 +42,7 @@ jobs:
           COLLECTION_NAME="${REPOSITORY_NAME//-versions}"
           sed -i "s|<!-- customize to your context -->.*<!-- until here -->|_ _ _ _ _ ✍️|g" README.md &&
           sed -i "s|<!-- here goes your collection name -->.*<!-- until here -->|$COLLECTION_NAME|g" README.md &&
-          sed -i "s|https://github.com/OpenTermsArchive/demo-versions/releases|https://github.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/releases|g" README.md &&
-          sed -i "s|https://github.com/OpenTermsArchive/demo-declarations|https://github.com/${REPOSITORY_OWNER}/${COLLECTION_NAME}-declarations|g" README.md
+          sed -i "s|https://github.com/OpenTermsArchive/demo|https://github.com/${REPOSITORY_OWNER}/${COLLECTION_NAME}|g" README.md
     
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/first-time-setup.yml
+++ b/.github/workflows/first-time-setup.yml
@@ -40,7 +40,8 @@ jobs:
           REPOSITORY_OWNER=${{ github.repository_owner }}
           REPOSITORY_NAME=${{ github.event.repository.name }}
           COLLECTION_NAME="${REPOSITORY_NAME//-versions}"
-          sed -i "s|# Demo versions|# $COLLECTION_NAME versions|g" README.md &&
+          sed -i "s|<!-- customize to your context -->.*<!-- until here -->|_ _ _ _ _ ✍️|g" README.md &&
+          sed -i "s|<!-- here goes your collection name -->.*<!-- until here -->|$COLLECTION_NAME|g" README.md &&
           sed -i "s|https://github.com/OpenTermsArchive/demo-versions/releases|https://github.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}/releases|g" README.md &&
           sed -i "s|https://github.com/OpenTermsArchive/demo-declarations|https://github.com/${REPOSITORY_OWNER}/${COLLECTION_NAME}-declarations|g" README.md
     

--- a/README.md
+++ b/README.md
@@ -1,31 +1,36 @@
-# Demo versions
+# Versions of terms from the `Demo` collection
 
-## Context
-
-[Open Terms Archive](https://opentermsarchive.org) is free and open source software that publicly records every version of the terms of digital services, increasing their readability and highlighting their changes to enable democratic oversight. Check out [opentermsarchive.org for more details](https://opentermsarchive.org).
-
-In the context of Open Terms Archive:
-- a **version** is a record of a service's terms cleaned of the non-significant parts (menus, ads,...) of the online document.
-Each version represents the state of the terms at the time of its capture, and they are publicly stored to provide a historical record of how the terms have evolved over time.
-- a **collection** refers to a grouping of terms tracked by Open Terms Archive characterised through a three-dimensional scope defined by language, jurisdiction and industry.
-
-Detailed information about this collection can be found at [its definition repository](https://github.com/OpenTermsArchive/demo-declarations).
-
-**This repository has to be considered as the database of versions for this collection.**
+The terms in this collection are tracked by the Open Terms Archive Core Team using [Open Terms Archive](https://opentermsarchive.org).
 
 ## Usage
 
-🔍 [Browse through versions](https://docs.opentermsarchive.org/navigate-history/) interactively on this user interface.
+### [🔍 Browse through versions](https://docs.opentermsarchive.org/navigate-history/) straight in this repository
 
-🔔 [Subscribe by RSS to terms changes](https://docs.opentermsarchive.org/subscribe-rss/) to be notified.
+### [🔔 Subscribe by RSS](https://docs.opentermsarchive.org/subscribe-rss/) to be notified of changes
 
-📥 [Download versions as dataset](https://github.com/OpenTermsArchive/demo-versions/releases) to explore data locally on your filesystem.
+### [🗂️ Download as dataset](https://github.com/OpenTermsArchive/demo-versions/releases) to analyse in depth
 
-If a specific service or specific terms for a service is missing from this collection, it may be available in others [referenced Open Terms Archive collections](https://opentermsarchive.org/#collections). If not, it can be added by following our documentation about [contributing terms](https://docs.opentermsarchive.org/contributing-terms).
+## Context
+
+[Open Terms Archive](https://opentermsarchive.org) is free and open source software that publicly records every version of the terms of digital services, increasing their readability and highlighting their changes to [enable democratic oversight](https://opentermsarchive.org/impact). In its [vocabulary](https://docs.opentermsarchive.org/#main-concepts):
+
+- A **version** is a record of a service’s terms cleaned of the legally irrelevant parts (e.g. menus, ads…) of an online document. Each version represents the state of the terms at a specific point in time. They are publicly recorded to provide a history of how the terms evolved over time.
+- A **collection** is a group of terms characterised by their language, jurisdiction and industry.
+
+Detailed information about this specific collection, including how to request or contribute terms, can be found in its [declarations repository](https://github.com/OpenTermsArchive/demo-declarations).
+
+## Missing terms
+
+Each collection has a specific scope, and its maintainers might or might not have the intention to track the terms you are interested in.
+
+If some versions are missing, the maintainers of this collection might benefit from your help: check [open issues](https://github.com/OpenTermsArchive/demo-declarations/issues) for known necessary corrections or open a new one.
+
+If specific services, or specific terms for a service, are missing from this collection, they may be available in other [public Open Terms Archive collections](https://opentermsarchive.org/#collections).
+
+If not, you may just be the best person to add them by [following the documentation](https://docs.opentermsarchive.org/contributing-terms)!
 
 - - -
+
 # License
 
-Data in this repository is distributed under an ODC-BY 1.0 license. That means you are free to share (to copy, distribute and use the database), to create (to produce works from the database), to adapt (to modify, transform and build upon the database) as long as you attribute the resulting works to _Open Terms Archive_.
-
-Contact the author if you have any specific need or question regarding licensing.
+Data in this repository is distributed under an ODC-BY 1.0 license. That means you are free to share (to copy, distribute and use the database), to create (to produce works from the database), to adapt (to modify, transform and build upon the database) as long as you attribute the resulting works to _Open Terms Archive Core Team and Open Terms Archive contributors_.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Versions of terms from the `Demo` collection
+# Versions of terms from the _<!-- here goes your collection name -->Demo<!-- until here -->_ collection
 
-The terms in this collection are tracked by the Open Terms Archive Core Team using [Open Terms Archive](https://opentermsarchive.org).
+The terms in this collection are tracked by <!-- customize to your context -->the Open Terms Archive Core Team<!-- until here --> using [Open Terms Archive](https://opentermsarchive.org).
 
 ## Usage
 
@@ -33,4 +33,4 @@ If not, you may just be the best person to add them by [following the documentat
 
 # License
 
-Data in this repository is distributed under an ODC-BY 1.0 license. That means you are free to share (to copy, distribute and use the database), to create (to produce works from the database), to adapt (to modify, transform and build upon the database) as long as you attribute the resulting works to _Open Terms Archive Core Team and Open Terms Archive contributors_.
+Data in this repository is distributed under an ODC-BY 1.0 license. That means you are free to share (to copy, distribute and use the database), to create (to produce works from the database), to adapt (to modify, transform and build upon the database) as long as you attribute the resulting works to *<!-- customize to your context -->Open Terms Archive Core Team<!-- until here --> and Open Terms Archive contributors*.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Versions of terms from the _<!-- here goes your collection name -->Demo<!-- until here -->_ collection
+# Versions of terms from the *<!-- here goes your collection name -->Demo<!-- until here -->* collection
 
 The terms in this collection are tracked by <!-- customize to your context -->the Open Terms Archive Core Team<!-- until here --> using [Open Terms Archive](https://opentermsarchive.org).
 


### PR DESCRIPTION
- Backport copywriting improvements from https://github.com/OpenTermsArchive/contrib-versions/pull/21
- Turn on templating for maintainer and collection names
- Generalise URL replacement pattern

See commit logs for implementation choices.

Replacements tested locally on the CLI.